### PR TITLE
Separate files

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -2,9 +2,6 @@ use rp_pico::hal;
 use rp_pico::hal::pac;
 use crate::board::hal::Clock;
 
-// HAL traits
-// use embedded_hal::digital::OutputPin;    todo
-
 // i2c elements
 use rp_pico::hal::fugit::RateExtU32;
 use rp_pico::hal::gpio::{FunctionI2C, Pin};
@@ -30,7 +27,12 @@ pub struct BoardComponents {
   >,
 
   // LED Outputs
-  // note: we're using PullDown to match what into_push_pull_output() returns, as we need to explicitly specify all generic type parameters in Rust struct definitions. The into_push_pull_output() function configures pins with PullDown by default, so by using the same type here, we ensure compatibility between our struct definition and the initialization code in setup_board()
+  // note: we're using PullDown to match what into_push_pull_output() 
+  //   returns, as we need to explicitly specify all generic type 
+  //   parameters in Rust struct definitions. The into_push_pull_output() 
+  //   function configures pins with PullDown by default, so by using 
+  //   the same type here, we ensure compatibility between our struct 
+  //   definition and the initialization code in setup_board()
   pub led_pin_led: Pin<hal::gpio::bank0::Gpio25, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>, // note: this is the onboard LED, whereas the others in the following initializations are LEDs physically connected to GPIO pins
   pub led_pin_yellow:
       Pin<hal::gpio::bank0::Gpio14, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
@@ -43,7 +45,7 @@ pub struct BoardComponents {
 }
 
 impl BoardComponents {
- // Set up all of our board components and return them in a single struct
+  // Set up all of our board components and return them in a single struct
   pub fn setup_board() -> BoardComponents {
     // This is the Pico-specific setup
     let mut peripherals = pac::Peripherals::take().unwrap();

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,0 +1,124 @@
+use rp_pico::hal;
+use rp_pico::hal::pac;
+use crate::board::hal::Clock;
+
+// HAL traits
+// use embedded_hal::digital::OutputPin;    todo
+
+// i2c elements
+use rp_pico::hal::fugit::RateExtU32;
+use rp_pico::hal::gpio::{FunctionI2C, Pin};
+
+// dht20 driver
+use cortex_m::delay::Delay;
+use dht20::Dht20;
+
+// Abstract the components we'll be using on the board into their own struct
+// This is useful for passing around the components in a single "object"
+// This struct can be expanded to include other components as needed (i.e. our LCD)
+pub struct BoardComponents {
+  // DHT-20 humidity sensor
+  pub sensor: Dht20<
+      hal::I2C<
+          pac::I2C1,
+          (
+              Pin<hal::gpio::bank0::Gpio18, FunctionI2C, hal::gpio::PullUp>,
+              Pin<hal::gpio::bank0::Gpio19, FunctionI2C, hal::gpio::PullUp>,
+          ),
+      >,
+      Delay,
+  >,
+
+  // LED Outputs
+  // note: we're using PullDown to match what into_push_pull_output() returns, as we need to explicitly specify all generic type parameters in Rust struct definitions. The into_push_pull_output() function configures pins with PullDown by default, so by using the same type here, we ensure compatibility between our struct definition and the initialization code in setup_board()
+  pub led_pin_led: Pin<hal::gpio::bank0::Gpio25, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>, // note: this is the onboard LED, whereas the others in the following initializations are LEDs physically connected to GPIO pins
+  pub led_pin_yellow:
+      Pin<hal::gpio::bank0::Gpio14, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
+  pub led_pin_red: Pin<hal::gpio::bank0::Gpio15, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
+  pub led_pin_green: Pin<hal::gpio::bank0::Gpio16, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
+  pub led_pin_yellow2:
+      Pin<hal::gpio::bank0::Gpio13, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
+  pub led_pin_red2: Pin<hal::gpio::bank0::Gpio12, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
+  // todo: Other peripherals can be added below, such as an LCD
+}
+
+impl BoardComponents {
+ // Set up all of our board components and return them in a single struct
+  pub fn setup_board() -> BoardComponents {
+    // This is the Pico-specific setup
+    let mut peripherals = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(peripherals.WATCHDOG);
+
+    // Configure the clocks
+    // (The default is to generate a 125 MHz system clock)
+    let clocks = hal::clocks::init_clocks_and_plls(
+        rp_pico::XOSC_CRYSTAL_FREQ,
+        peripherals.XOSC,
+        peripherals.CLOCKS,
+        peripherals.PLL_SYS,
+        peripherals.PLL_USB,
+        &mut peripherals.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // The delay object lets us wait for specified amounts of time (in
+    // milliseconds)
+    let delay: Delay = Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(peripherals.SIO);
+
+    // Set the pins up according to their function on this particular board
+    let pins = rp_pico::Pins::new(
+        peripherals.IO_BANK0,
+        peripherals.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut peripherals.RESETS,
+    );
+
+    // Set the onboard RPP LED to be an output
+    let led_pin_led = pins.led.into_push_pull_output();
+    // Set the GPIO 14, 15, 16 (Pico pins 19, 20, 21) to be an output
+    let led_pin_yellow = pins.gpio14.into_push_pull_output();
+    let led_pin_red = pins.gpio15.into_push_pull_output();
+    let led_pin_green = pins.gpio16.into_push_pull_output();
+    let led_pin_yellow2 = pins.gpio13.into_push_pull_output();
+    let led_pin_red2 = pins.gpio12.into_push_pull_output();
+
+    // Configure two pins as being I²C, not GPIO
+    let sda_pin = pins.gpio18.reconfigure();
+    let scl_pin = pins.gpio19.reconfigure();
+
+    // Set up DHT20 sensor
+    let sensor = Dht20::new(
+        hal::I2C::i2c1(
+            peripherals.I2C1,
+            sda_pin,
+            scl_pin,
+            400.kHz(),
+            &mut peripherals.RESETS,
+            &clocks.system_clock,
+        ),
+        0x38,
+        delay,
+    );
+
+    // todo: set up LCD if present on board (and after adding it to the struct)
+
+    // Return all components in the form of the struct (LCD will need to be added here as well)
+    BoardComponents {
+        sensor,
+        led_pin_led,
+        led_pin_yellow,
+        led_pin_red,
+        led_pin_green,
+        led_pin_yellow2,
+        led_pin_red2,
+    }
+  } 
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+// Compile without standard library
+#![no_std]
+#![no_main]
+
+pub mod board;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,25 +4,13 @@
 
 // Import HAL crates
 use rp_pico::entry;
-use rp_pico::hal;
-use rp_pico::hal::pac;
-use rp_pico::hal::prelude::*;
 
 // HAL traits
 use embedded_hal::digital::OutputPin;
 
-// i2c elements
-use rp_pico::hal::fugit::RateExtU32;
-use rp_pico::hal::gpio::{FunctionI2C, Pin};
-
-// dht20 driver
-use cortex_m::delay::Delay;
-use dht20::Dht20;
-
 use panic_halt as _;
 
 mod board;
-
 
 
 // Main entry point

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,119 +21,15 @@ use dht20::Dht20;
 
 use panic_halt as _;
 
-// Abstract the components we'll be using on the board into their own struct
-// This is useful for passing around the components in a single "object"
-// This struct can be expanded to include other components as needed (i.e. our LCD)
-struct BoardComponents {
-    // DHT-20 humidity sensor
-    sensor: Dht20<
-        hal::I2C<
-            pac::I2C1,
-            (
-                Pin<hal::gpio::bank0::Gpio18, FunctionI2C, hal::gpio::PullUp>,
-                Pin<hal::gpio::bank0::Gpio19, FunctionI2C, hal::gpio::PullUp>,
-            ),
-        >,
-        Delay,
-    >,
+mod board;
 
-    // LED Outputs
-    // note: we're using PullDown to match what into_push_pull_output() returns, as we need to explicitly specify all generic type parameters in Rust struct definitions. The into_push_pull_output() function configures pins with PullDown by default, so by using the same type here, we ensure compatibility between our struct definition and the initialization code in setup_board()
-    led_pin_led: Pin<hal::gpio::bank0::Gpio25, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>, // note: this is the onboard LED, whereas the others in the following initializations are LEDs physically connected to GPIO pins
-    led_pin_yellow:
-        Pin<hal::gpio::bank0::Gpio14, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
-    led_pin_red: Pin<hal::gpio::bank0::Gpio15, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
-    led_pin_green: Pin<hal::gpio::bank0::Gpio16, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
-    led_pin_yellow2:
-        Pin<hal::gpio::bank0::Gpio13, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
-    led_pin_red2: Pin<hal::gpio::bank0::Gpio12, hal::gpio::FunctionSioOutput, hal::gpio::PullDown>,
-    // todo: Other peripherals can be added below, such as an LCD
-}
 
-// Set up all of our board components and return them in a single struct
-fn setup_board() -> BoardComponents {
-    // This is the Pico-specific setup
-    let mut peripherals = pac::Peripherals::take().unwrap();
-    let core = pac::CorePeripherals::take().unwrap();
-
-    // Set up the watchdog driver - needed by the clock setup code
-    let mut watchdog = hal::Watchdog::new(peripherals.WATCHDOG);
-
-    // Configure the clocks
-    // (The default is to generate a 125 MHz system clock)
-    let clocks = hal::clocks::init_clocks_and_plls(
-        rp_pico::XOSC_CRYSTAL_FREQ,
-        peripherals.XOSC,
-        peripherals.CLOCKS,
-        peripherals.PLL_SYS,
-        peripherals.PLL_USB,
-        &mut peripherals.RESETS,
-        &mut watchdog,
-    )
-    .ok()
-    .unwrap();
-
-    // The delay object lets us wait for specified amounts of time (in
-    // milliseconds)
-    let delay: Delay = Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
-
-    // The single-cycle I/O block controls our GPIO pins
-    let sio = hal::Sio::new(peripherals.SIO);
-
-    // Set the pins up according to their function on this particular board
-    let pins = rp_pico::Pins::new(
-        peripherals.IO_BANK0,
-        peripherals.PADS_BANK0,
-        sio.gpio_bank0,
-        &mut peripherals.RESETS,
-    );
-
-    // Set the onboard RPP LED to be an output
-    let led_pin_led = pins.led.into_push_pull_output();
-    // Set the GPIO 14, 15, 16 (Pico pins 19, 20, 21) to be an output
-    let led_pin_yellow = pins.gpio14.into_push_pull_output();
-    let led_pin_red = pins.gpio15.into_push_pull_output();
-    let led_pin_green = pins.gpio16.into_push_pull_output();
-    let led_pin_yellow2 = pins.gpio13.into_push_pull_output();
-    let led_pin_red2 = pins.gpio12.into_push_pull_output();
-
-    // Configure two pins as being I²C, not GPIO
-    let sda_pin = pins.gpio18.reconfigure();
-    let scl_pin = pins.gpio19.reconfigure();
-
-    // Set up DHT20 sensor
-    let sensor = Dht20::new(
-        hal::I2C::i2c1(
-            peripherals.I2C1,
-            sda_pin,
-            scl_pin,
-            400.kHz(),
-            &mut peripherals.RESETS,
-            &clocks.system_clock,
-        ),
-        0x38,
-        delay,
-    );
-
-    // todo: set up LCD if present on board (and after adding it to the struct)
-
-    // Return all components in the form of the struct (LCD will need to be added here as well)
-    BoardComponents {
-        sensor,
-        led_pin_led,
-        led_pin_yellow,
-        led_pin_red,
-        led_pin_green,
-        led_pin_yellow2,
-        led_pin_red2,
-    }
-}
 
 // Main entry point
 #[entry]
 fn main() -> ! {
     // Set up the board and get all components via our struct
-    let mut components = setup_board();
+    let mut components = board::BoardComponents::setup_board();
 
     // sensor.read will produce two f32 values: reading.hum and reading.temp
     match components.sensor.read() {


### PR DESCRIPTION
I had opened issue #11 "Figure out how to modularize code in Rust". After Nic's modularizing with a struct and function in `main.rs` (pull request / merge #15), this pull request represents the next step of taking those to a separate file, as it:
 - creates a `lib.rs` file, which though not necessary seems to be a best practice
 - takes the `BoardComponents` struct into a new `board.rs` file, as a public struct
 - takes the `setup_board()` function into the `board.rs` file and within the `BoardComponents` implementation, as a public function.
 - moves many required imports (use statements) from `main.rs` into the board.rs file

__Important notes:__
 - This pull request is to merge with the `emb-hal-i2c-dh20` (same as Nic's merge #15), because that is where our working code is.
 - Matt currently has a pull request #16 to set up an led array interface.  Once Matt's is merged, this pull request (if we decide to implement it) will need to be reconciled in order to merge.
 - I am not closing issue #11 with this pull request, though I have no objection to closing it. It may be that further modularization is desirable. Since I'm still learning Rust, I plan to continue to study this.