### PR TITLE
Provides proof of concept for LCD hello world, updates Dht fork for mutable borrow of Delay object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 default-run = "OSU-RPMH"
 
 [dependencies]
-cortex-m = "0.7"
+cortex-m = "0.7.7"
 cortex-m-rt = "0.7"
 embedded-hal = "0.2.7"
 rp-pico = "0.9"
 panic-halt = "1.0.0"
 log = "0.4.27"
+liquidcrystal_i2c-rs = "0.1.0"

--- a/src/board.rs
+++ b/src/board.rs
@@ -12,12 +12,78 @@ use crate::dht::Dht20;
 
 use cortex_m::delay::Delay;
 
+// use rppal::{gpio::Gpio, i2c::I2c};
+// new library crate that works for the LCD; 
+use liquidcrystal_i2c_rs::{Backlight, Display, Lcd};
+static  LCD_ADDRESS: u8 = 0x27;
+
+// ~~~ +++ ~~~ +++ // errata from trying
+
+    // use crate::delay_wrapper::DelayWrapper;
+
+    // use embedded_hal::blocking::delay::DelayNs;
+// use eh1::delay::DelayNs;
+    // use cortex_m::delay::DelayNs;
+    // use embedded_hal::delay::DelayNs;
+
+    // impl DelayNs<u32> for Delay {
+    // impl eh1::delay::DelayNs for cortex_m::delay::Delay {
+    //     fn delay_ns(&mut self, ns: u32) {
+    //         // Convert nanoseconds to microseconds (1 microsecond = 1000 nanoseconds)
+    //         let us = ns / 1000;
+    //         self.delay_us(us);
+    //     }
+    // }
+    // impl DelayNs<u32> for Delay {
+    //     fn delay_ns(&mut self, ns: u32) {
+    //         // Convert nanoseconds to microseconds (1 microsecond = 1000 nanoseconds)
+    //         let us = ns / 1000;
+    //         self.delay_us(us);
+    //     }
+    // }
+
+// use rp_pico::hal::Timer;
+
+// use lcd1602_driver::{
+//     command::{DataWidth, MoveDirection, State},
+//     lcd::{self, Anim, Basic, CGRAMGraph, Ext, ExtRead, FlipStyle, Lcd, MoveStyle},
+//     sender::I2cSender,
+//     utils::BitOps,
+// };
+
+    // use lcd1602_driver::{
+    //     builder::{Builder, BuilderAPI},
+    //     enums::{
+    //         animation::{FlipStyle, MoveStyle},
+    //         basic_command::{Font, LineMode, MoveDirection, ShiftType, State},
+    //     },
+    //     pins::{FourPinsAPI, Pins},
+    //     utils::BitOps,
+    //     LCDAnimation, LCDBasic, LCDExt,
+    // };
+
+    // use lcd1602_rs::LCD1602;
+
+    // const HEART: [u8; 8] = [
+    //     0b00000, 0b00000, 0b01010, 0b11111, 0b01110, 0b00100, 0b00000, 0b00000,
+    // ];
+
+// const HEART: CGRAMGraph = CGRAMGraph {
+//     upper: [
+//         0b00000, 0b00000, 0b01010, 0b11111, 0b01110, 0b00100, 0b00000, 0b00000,
+//     ],
+//     lower: Some([0b00100, 0b01110, 0b00100]),
+// };
+
+// ~~~ +++ ~~~ +++ 
+
 // Abstract the components we'll be using on the board into their own struct
 // This is useful for passing around the components in a single "object"
 // This struct can be expanded to include other components as needed (i.e. our LCD)
-pub struct BoardComponents {
+    // updated to pass mutable borrowable delay, need to pass from main to possibly fix..
+pub struct BoardComponents<'a> {
     // DHT-20 humidity sensor
-    pub sensor: Dht20<
+    pub sensor: Dht20<'a,
         hal::I2C<
             pac::I2C1,
             (
@@ -25,9 +91,16 @@ pub struct BoardComponents {
                 Pin<hal::gpio::bank0::Gpio19, FunctionI2C, hal::gpio::PullUp>,
             ),
         >,
-        Delay,
+        Delay, 
+        // DelayWrapper<'a>,
+        // &'a mut Delay, // Borrow DELAY instead of owning it
         hal::i2c::Error, // compiler requests explicit definition of third argument for I2C error
     >,
+
+    // Delay object // errata
+    // pub delay: Delay, // Added as a public field
+
+    // pub delay: DelayWrapper<'a>, // Add DelayWrapper as a public field
 
     // LED Outputs
     // note: we're using PullDown to match what into_push_pull_output()
@@ -46,10 +119,10 @@ pub struct BoardComponents {
     // note: END lines added manually from mjanderson's code during merge. todo: remove this comment line once merge is complete
     // todo: Other peripherals can be added below, such as an LCD
 }
-
-impl BoardComponents {
+// updated to pass mutable borrowable delay, would need to pass delay, pins, and both i2c objects into setup method to possibly fix... 
+impl<'a> BoardComponents<'a> {
     // Set up all of our board components and return them in a single struct
-    pub fn setup_board() -> BoardComponents {
+    pub fn setup_board() -> BoardComponents<'a> {
         // This is the Pico-specific setup
         let mut peripherals = pac::Peripherals::take().unwrap();
         let core = pac::CorePeripherals::take().unwrap();
@@ -71,9 +144,14 @@ impl BoardComponents {
         .ok()
         .unwrap();
 
-        // The delay object lets us wait for specified amounts of time (in
-        // milliseconds)
-        let delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz()); // updated to compile the Dht mod solution // note: added manually during merge by zwartn. todo: remove NOTE, not line, once merge is complete
+        // The delay object lets us wait for specified amounts of time (in milliseconds)
+        // update as mutable for borrow
+        let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz()); // updated to compile the Dht mod solution by suhrmosu
+        
+        // let mut delay =  <dyn eh1::delay::DelayNs as DelayNs>::cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz()); 
+        // let mut delay = core.SYST.delay(&clocks);
+        // let mut delay = <dyn embedded_hal::delay::DelayNs>::new(core.SYST, clocks.system_clock.freq().to_Hz());
+        // let mut delay = core.SYST.delay(&clocks);
 
         // The single-cycle I/O block controls our GPIO pins
         let sio = hal::Sio::new(peripherals.SIO);
@@ -112,13 +190,53 @@ impl BoardComponents {
         );
 
         // Set up DHT20 sensor
-        let sensor = Dht20::new(i2c, 0x38, delay);
+        // let sensor = Dht20::new(i2c, 0x38, delay);
+        let sensor = Dht20::new(i2c, 0x38, &mut delay); // borrow the delay as mutable 
 
         // todo: set up LCD if present on board (and after adding it to the struct)
+
+        // Configure two pins as being I²C, not GPIO
+        let sda_lcd_pin = pins.gpio0.reconfigure(); 
+        let scl_lcd_pin = pins.gpio1.reconfigure(); 
+
+        // init for LCD embedded hal I2C
+        let mut i2clcd = hal::I2C::i2c0(
+            peripherals.I2C0,
+            sda_lcd_pin,
+            scl_lcd_pin,
+            100.kHz(),
+            &mut peripherals.RESETS,
+            &clocks.system_clock,
+        );
+
+        // errata from crate that does not mesh well with embedded hal versions 
+        // let mut sender = I2cSender::new(&mut i2clcd, 0x27u8);
+
+        // let lcd_config = lcd::Config::default().set_data_width(DataWidth::Bit4);
+
+        // let mut delayer = sensor.delay_ms;
+
+        // init LCD1602
+        // let mut lcd = Lcd::new(&mut sender,  &mut delay, lcd_config, None);
+
+        // draw a little heart in CGRAM
+        // lcd.write_graph_to_cgram(0, &HEART);
+
+        // let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, &mut sensor.delay()).unwrap();
+        // old attempt implement new library; 
+        // let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, &mut delay).unwrap();
+        let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, sensor.delay()).unwrap();
+        // test LCD in place // to remove if Board components is revived to work again
+        lcd.set_display(Display::On).unwrap();
+        lcd.set_backlight(Backlight::On).unwrap();
+
+        lcd.clear().unwrap();
+        lcd.print("Hello World!").unwrap();
 
         // Return all components in the form of the struct (LCD will need to be added here as well)
         BoardComponents {
             sensor,
+            // lcd, // need to implement in component type struct
             led_pin_led,
             led_array,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,6 @@
 #![no_main]
 #![allow(non_snake_case)] // Allow our crate to have a non-snake-case name
 
-pub mod board;
+// pub mod board; // depreciated for LCD proof-of-concept to enable repeat borrow of delay in main loop
 pub mod dht;
 pub mod leds;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,17 +9,121 @@ use rp_pico::entry;
 // use embedded_hal::digital::OutputPin; // depreciated due to updated version to utilie embedded-hal = "0.2.7" for mod solution of Delay
 use embedded_hal::digital::v2::OutputPin;
 
-mod board;
+// mod board; // depreciated for LCD proof-of-concept to enable repeat borrow of delay in main loop
 mod dht; // note: the original crate for Dht20 has been replicated (forked) locally to modify for parallel calls to Delay. This import (src/dht.rs) is our custom variation
 mod leds;
+
+use rp_pico::hal;
+use rp_pico::hal::pac;
+use rp_pico::hal::prelude::*;
+
+// i2c elements
+use rp_pico::hal::fugit::RateExtU32;
+use rp_pico::hal::gpio::{FunctionI2C, Pin};
+
+// custom adapted dht20 driver import
+use crate::dht::Dht20;
+
+use cortex_m::delay::Delay;
+
+use liquidcrystal_i2c_rs::{Backlight, Display, Lcd};
+static  LCD_ADDRESS: u8 = 0x27;
 
 use panic_halt as _;
 
 // Main entry point
 #[entry]
 fn main() -> ! {
+    // local init from Board mod
+    // This is the Pico-specific setup
+    let mut peripherals = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(peripherals.WATCHDOG);
+
+    // Configure the clocks
+    // (The default is to generate a 125 MHz system clock)
+    let clocks = hal::clocks::init_clocks_and_plls(
+        rp_pico::XOSC_CRYSTAL_FREQ,
+        peripherals.XOSC,
+        peripherals.CLOCKS,
+        peripherals.PLL_SYS,
+        peripherals.PLL_USB,
+        &mut peripherals.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // The delay object lets us wait for specified amounts of time (in milliseconds)
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz()); // updated to compile the Dht mod solution by suhrmosu
+    
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(peripherals.SIO);
+
+    // Set the pins up according to their function on this particular board
+    let pins = rp_pico::Pins::new(
+        peripherals.IO_BANK0,
+        peripherals.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut peripherals.RESETS,
+    );
+
+    // Set the onboard RPP LED to be an output
+    let mut led_pin_led = pins.led.into_push_pull_output();
+    // Initialize an led array with five led pins
+    let mut led_array = leds::LedArray::new(
+        pins.gpio12,
+        pins.gpio13,
+        pins.gpio14,
+        pins.gpio15,
+        pins.gpio16,
+    );
+
+    // Configure two pins as being I²C, not GPIO
+    let sda_pin = pins.gpio18.reconfigure();
+    let scl_pin = pins.gpio19.reconfigure();
+
+    // init for embedded hal I2C
+    let i2c = hal::I2C::i2c1(
+        peripherals.I2C1,
+        sda_pin,
+        scl_pin,
+        400.kHz(),
+        &mut peripherals.RESETS,
+        &clocks.system_clock,
+    );
+
+    // Set up DHT20 sensor
+    // let sensor = Dht20::new(i2c, 0x38, delay);
+    let mut sensor = Dht20::new(i2c, 0x38, &mut delay); // mutable borrow of delay
+
+    // Configure two pins as being I²C for LCD SDA/SCL
+    let sda_lcd_pin = pins.gpio0.reconfigure(); 
+    let scl_lcd_pin = pins.gpio1.reconfigure(); 
+
+    let mut i2clcd = hal::I2C::i2c0(
+        peripherals.I2C0,
+        sda_lcd_pin,
+        scl_lcd_pin,
+        100.kHz(),
+        &mut peripherals.RESETS,
+        &clocks.system_clock,
+    );
+
+    // let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, &mut sensor.delay()).unwrap();
+    // let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, &mut sensor.delay()).unwrap();
+    // let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, sensor.delay()).unwrap();
+
+    // lcd.set_display(Display::On).unwrap();
+    // lcd.set_backlight(Backlight::On).unwrap();
+
+    // lcd.clear().unwrap();
+    // lcd.print("Hello World!").unwrap();
+
     // Set up the board and get all components via our struct
-    let mut components = board::BoardComponents::setup_board();
+    // let mut components = board::BoardComponents::setup_board();
 
     // sensor.read will produce two f32 values: reading.hum and reading.temp
     // match components.sensor.read() {
@@ -46,24 +150,59 @@ fn main() -> ! {
     //     }
     // }
 
+    // init floating point pass-through variable to copy reading.hum before translating to string to print to LCD
+    let mut the_hum: f32 = 101.0;
+
     // To prevent a return from main()
     loop {
-        match components.sensor.read() {
+        // match components.sensor.read() {
+        //     Ok(reading) => {
+        //         components.led_array.update(reading);
+        //     }
+        //     Err(_e) => {
+        //         components.led_pin_led.set_high().unwrap();
+        //         // error!("Error reading sensor: {e:?}");
+        //     }
+        // }
+        // Dht20 sensor crate class now has a delay function appended to it
+        // components.sensor.delay_ms(10000); // sleep 10 seconds between readings
+
+        match sensor.read() {
             Ok(reading) => {
-                components.led_array.update(reading);
+                the_hum = reading.hum;
+                led_array.update(reading);
             }
             Err(_e) => {
-                components.led_pin_led.set_high().unwrap();
+                led_pin_led.set_high().unwrap();
                 // error!("Error reading sensor: {e:?}");
             }
         }
-        // Dht20 sensor crate class now has a delay function appended to it
-        components.sensor.delay_ms(10000); // sleep 10 seconds between readings
+        // lcd.print("Hello World!").unwrap();
 
-        // reset LEDs to off
-        components.led_array.clear();
+        // sensor.delay_ms(10000); // sleep 10 seconds between readings
+
+        // // reset LEDs to off
+        // // components.led_array.clear();
+        // led_array.clear();
 
         // todo: use our components here via the `components` struct
+        let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, sensor.delay()).unwrap();
+
+        lcd.set_display(Display::On).unwrap();
+        lcd.set_backlight(Backlight::On).unwrap();
+
+        lcd.clear().unwrap();
+        // let hum_string = the_hum.to_string();
+        // let hum_string = format!("{}", the_hum);
+        // lcd.print("{}",the_hum).unwrap();
+        // lcd.print(hum_string).unwrap();
+        lcd.print("Hello World!").unwrap();
+
+        sensor.delay_ms(10000); // sleep 10 seconds between readings
+
+        // reset LEDs to off
+        // components.led_array.clear();
+        led_array.clear();
     }
 }
 // end of file


### PR DESCRIPTION
Continuing our grappling with the Rust strict ownership model and the RPP compatibility with various component additions, this PR represents the best attempt to reconcile functionality for our key scope deliverables. 

Various Rust crate library integrations were researched and attempted to integrate with our existing project development accomplishments. These ran into various unexpected roadblocks, including the ownership of the Delay feature of the RPP (again), as well as the versioning of embedded hal and it's representation of delay as a nanosecond level precision, versus the millisecond precision we had incorporated.  Further development may provide solutions to iron out this discrepancy, which has been circumvented in this iteration of solution. 

This 'proof-of-concept' solution integrates a newly researched Rust crate `liquidcrystal_i2c_rs` for a stopgap solution which does not object to the current version of Delay, and further updates the forked local implementation of `Dht20` that was previously modified. The updated Dht module now only borrows the instance of Delay opposed to taking ownership, while also providing a mutable pass through to provide LCD a secondary option to borrow the borrowed object. The Rust compiler and ownership model is so strict, it will not compile if two component classes both attempt to borrow the object (Delay) in the loop as is a part of the critical scope for the project.  

```
error[E0499]: cannot borrow `delay` as mutable more than once at a time
   --> src/main.rs:189:58
    |
100 |     let mut sensor = Dht20::new(i2c, 0x38, &mut delay); // mutable borrow of delay
    |                                            ---------- first mutable borrow occurs here
...
189 |         let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, &mut delay).unwrap();
    |                                                          ^^^^^^^^^^ second mutable borrow occurs here
...
211 |         sensor.delay_ms(10000); // sleep 10 seconds between readings
    |         ------ first borrow later used here
```

However, surprisingly, the equivalent functionality can be achieved through passing the second component class LCD a mutable borrowed instance of the borrowed instance (two layers). This only compiles when the lcd object is initialized dynamically within the loop on each iterative pass, where Rust can revoke it's access to the borrowed object after it has fulfilled it's function on each iteration.
```
    // added mutable borrow of DELAY for LCD
    pub fn delay(&mut self) -> &mut DELAY {
        &mut self.delay
    }
```
`let mut lcd = Lcd::new(&mut i2clcd, LCD_ADDRESS, sensor.delay()).unwrap();
`

The result is an imperfect yet functional implementation of our scope requirement: continuously looping over a dynamic reading of the humidity sensor, dynamic lighting of the LED array, printing to the LCD display, and utilizing the Delay method to sleep the loop for 10 seconds before repeating. The negative repercussion of this being the need to depreciate our previous work to abstract the board setup and component structure in a module. Further development work may yield the answer to pass the necessary RPP core objects from main into the Board module to abstract part of the setup initialization, though Rust was very clear that the mutable borrow of Delay cannot be abstracted, as the setup function would own the instance, while it is instead the parent main function which must retain ownership to enable this mutable borrow workflow.  

Solution has been tested, compiled, and functions on the hardware in the loop with Dht mod showing a dynamic humidity reading on the LEDs, and the hello world LCD print out; 
forked content further updated for educational demonstration and research